### PR TITLE
Add Next.js expense tracker demo

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-100 text-gray-900;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import './globals.css';
+import { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'Expense Tracker',
+  description: 'Track your expenses with ease',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import ExpenseTracker from '../components/ExpenseTracker';
+
+export default function Page() {
+  return <ExpenseTracker />;
+}

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { Expense, Category } from '../lib/types';
+
+interface Props {
+  expenses: Expense[];
+}
+
+export default function Dashboard({ expenses }: Props) {
+  const total = expenses.reduce((sum, e) => sum + e.amount, 0);
+  const byCategory: Record<Category, number> = {
+    Food: 0,
+    Transportation: 0,
+    Entertainment: 0,
+    Shopping: 0,
+    Bills: 0,
+    Other: 0,
+  };
+  expenses.forEach((e) => {
+    byCategory[e.category] += e.amount;
+  });
+
+  const topCategory = Object.entries(byCategory).sort((a, b) => b[1] - a[1])[0];
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+      <div className="bg-white p-4 rounded shadow">
+        <h3 className="font-medium">Total Spending</h3>
+        <p className="text-2xl font-bold">${total.toFixed(2)}</p>
+      </div>
+      <div className="bg-white p-4 rounded shadow">
+        <h3 className="font-medium">Top Category</h3>
+        <p className="text-xl">{topCategory ? `${topCategory[0]} - $${topCategory[1].toFixed(2)}` : 'N/A'}</p>
+      </div>
+      <div className="bg-white p-4 rounded shadow col-span-1 md:col-span-3">
+        <h3 className="font-medium mb-2">Spending by Category</h3>
+        <div className="space-y-1">
+          {Object.entries(byCategory).map(([cat, amt]) => (
+            <div key={cat} className="flex items-center">
+              <span className="w-24">{cat}</span>
+              <div className="flex-1 bg-gray-200 h-3 rounded">
+                <div
+                  className="bg-blue-500 h-3 rounded"
+                  style={{ width: total ? `${(amt / total) * 100}%` : '0%' }}
+                />
+              </div>
+              <span className="ml-2">${amt.toFixed(2)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ExpenseForm.tsx
+++ b/components/ExpenseForm.tsx
@@ -1,0 +1,97 @@
+'use client';
+import { useState } from 'react';
+import { Category, Expense } from '../lib/types';
+
+interface Props {
+  onSave: (expense: Omit<Expense, 'id'>) => void;
+  initial?: Expense | null;
+}
+
+const categories: Category[] = [
+  'Food',
+  'Transportation',
+  'Entertainment',
+  'Shopping',
+  'Bills',
+  'Other',
+];
+
+export default function ExpenseForm({ onSave, initial = null }: Props) {
+  const [date, setDate] = useState(initial?.date ?? '');
+  const [amount, setAmount] = useState(initial?.amount.toString() ?? '');
+  const [category, setCategory] = useState<Category>(initial?.category ?? 'Food');
+  const [description, setDescription] = useState(initial?.description ?? '');
+  const [error, setError] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!date || !amount) {
+      setError('Date and amount are required');
+      return;
+    }
+    const num = Number(amount);
+    if (isNaN(num) || num <= 0) {
+      setError('Amount must be a positive number');
+      return;
+    }
+    onSave({ date, amount: num, category, description });
+    setDate('');
+    setAmount('');
+    setCategory('Food');
+    setDescription('');
+    setError('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 p-4 bg-white rounded shadow">
+      {error && <p className="text-red-600">{error}</p>}
+      <div className="flex flex-col">
+        <label className="font-medium">Date</label>
+        <input
+          type="date"
+          className="border rounded p-2"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          required
+        />
+      </div>
+      <div className="flex flex-col">
+        <label className="font-medium">Amount</label>
+        <input
+          type="number"
+          step="0.01"
+          className="border rounded p-2"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          required
+        />
+      </div>
+      <div className="flex flex-col">
+        <label className="font-medium">Category</label>
+        <select
+          className="border rounded p-2"
+          value={category}
+          onChange={(e) => setCategory(e.target.value as Category)}
+        >
+          {categories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="flex flex-col">
+        <label className="font-medium">Description</label>
+        <input
+          type="text"
+          className="border rounded p-2"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </div>
+      <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+        Save Expense
+      </button>
+    </form>
+  );
+}

--- a/components/ExpenseList.tsx
+++ b/components/ExpenseList.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { Expense } from '../lib/types';
+
+interface Props {
+  expenses: Expense[];
+  onDelete: (id: string) => void;
+  onEdit: (id: string) => void;
+}
+
+export default function ExpenseList({ expenses, onDelete, onEdit }: Props) {
+  return (
+    <table className="min-w-full bg-white rounded shadow text-sm">
+      <thead>
+        <tr>
+          <th className="p-2">Date</th>
+          <th className="p-2">Amount</th>
+          <th className="p-2">Category</th>
+          <th className="p-2">Description</th>
+          <th className="p-2">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {expenses.map((e) => (
+          <tr key={e.id} className="border-t">
+            <td className="p-2">{new Date(e.date).toLocaleDateString()}</td>
+            <td className="p-2">${e.amount.toFixed(2)}</td>
+            <td className="p-2">{e.category}</td>
+            <td className="p-2">{e.description}</td>
+            <td className="p-2 space-x-2">
+              <button
+                onClick={() => onEdit(e.id)}
+                className="text-blue-600 hover:underline"
+              >
+                Edit
+              </button>
+              <button
+                onClick={() => onDelete(e.id)}
+                className="text-red-600 hover:underline"
+              >
+                Delete
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/components/ExpenseTracker.tsx
+++ b/components/ExpenseTracker.tsx
@@ -1,0 +1,72 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { Expense } from '../lib/types';
+import ExpenseForm from './ExpenseForm';
+import ExpenseList from './ExpenseList';
+import Dashboard from './Dashboard';
+import ExportCSV from './ExportCSV';
+import Filters from './Filters';
+
+export default function ExpenseTracker() {
+  const [expenses, setExpenses] = useState<Expense[]>([]);
+  const [editing, setEditing] = useState<Expense | null>(null);
+  const [categoryFilter, setCategoryFilter] = useState('All');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('expenses');
+    if (stored) {
+      setExpenses(JSON.parse(stored));
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('expenses', JSON.stringify(expenses));
+  }, [expenses]);
+
+  const saveExpense = (e: Omit<Expense, 'id'>) => {
+    if (editing) {
+      setExpenses((prev) => prev.map((ex) => (ex.id === editing.id ? { ...editing, ...e } : ex)));
+      setEditing(null);
+    } else {
+      setExpenses((prev) => [...prev, { ...e, id: Date.now().toString() }]);
+    }
+  };
+
+  const handleDelete = (id: string) => {
+    setExpenses((prev) => prev.filter((e) => e.id !== id));
+  };
+
+  const handleEdit = (id: string) => {
+    const ex = expenses.find((e) => e.id === id);
+    if (ex) setEditing(ex);
+  };
+
+  const filtered = expenses.filter((e) => {
+    if (categoryFilter !== 'All' && e.category !== categoryFilter) return false;
+    if (startDate && new Date(e.date) < new Date(startDate)) return false;
+    if (endDate && new Date(e.date) > new Date(endDate)) return false;
+    return true;
+  });
+
+  return (
+    <div className="space-y-4 p-4 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold text-center">Expense Tracker</h1>
+      <ExpenseForm onSave={saveExpense} initial={editing} />
+      <Filters
+        category={categoryFilter}
+        setCategory={setCategoryFilter}
+        start={startDate}
+        setStart={setStartDate}
+        end={endDate}
+        setEnd={setEndDate}
+      />
+      <Dashboard expenses={filtered} />
+      <ExpenseList expenses={filtered} onDelete={handleDelete} onEdit={handleEdit} />
+      <div className="flex justify-end">
+        <ExportCSV expenses={filtered} />
+      </div>
+    </div>
+  );
+}

--- a/components/ExportCSV.tsx
+++ b/components/ExportCSV.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { Expense } from '../lib/types';
+
+interface Props {
+  expenses: Expense[];
+}
+
+export default function ExportCSV({ expenses }: Props) {
+  const handleExport = () => {
+    const header = 'Date,Amount,Category,Description\n';
+    const rows = expenses
+      .map((e) =>
+        [e.date, e.amount.toFixed(2), e.category, e.description.replace(/,/g, ' ')].join(',')
+      )
+      .join('\n');
+    const blob = new Blob([header + rows], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'expenses.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <button onClick={handleExport} className="bg-green-600 text-white px-4 py-2 rounded">
+      Export CSV
+    </button>
+  );
+}

--- a/components/Filters.tsx
+++ b/components/Filters.tsx
@@ -1,0 +1,47 @@
+'use client';
+import { Category } from '../lib/types';
+
+interface Props {
+  category: string;
+  setCategory: (c: string) => void;
+  start: string;
+  setStart: (d: string) => void;
+  end: string;
+  setEnd: (d: string) => void;
+}
+
+const categories: (Category | 'All')[] = [
+  'All',
+  'Food',
+  'Transportation',
+  'Entertainment',
+  'Shopping',
+  'Bills',
+  'Other',
+];
+
+export default function Filters({ category, setCategory, start, setStart, end, setEnd }: Props) {
+  return (
+    <div className="flex flex-wrap gap-2 mb-4">
+      <select className="border p-2 rounded" value={category} onChange={(e) => setCategory(e.target.value)}>
+        {categories.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
+      </select>
+      <input
+        type="date"
+        className="border p-2 rounded"
+        value={start}
+        onChange={(e) => setStart(e.target.value)}
+      />
+      <input
+        type="date"
+        className="border p-2 rounded"
+        value={end}
+        onChange={(e) => setEnd(e.target.value)}
+      />
+    </div>
+  );
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,15 @@
+export type Category =
+  | 'Food'
+  | 'Transportation'
+  | 'Entertainment'
+  | 'Shopping'
+  | 'Bills'
+  | 'Other';
+
+export interface Expense {
+  id: string;
+  date: string; // ISO string
+  amount: number;
+  category: Category;
+  description: string;
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "expense-tracker",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.24",
+    "tailwindcss": "3.4.4",
+    "typescript": "5.4.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+    './pages/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Next.js project skeleton with TailwindCSS
- implement client-side expense tracker with localStorage
- provide dashboard summaries and CSV export functionality

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a82f9ce4c8327a4ca36a7c4591f79